### PR TITLE
Prevent Members from Booking Reservations in the Past

### DIFF
--- a/timeslots/templates/timeslots/timeslot_detail.html
+++ b/timeslots/templates/timeslots/timeslot_detail.html
@@ -15,7 +15,7 @@
 
 <div class="row">
   <div class="col-md-6 mb-4">
-    {% if timeslot.has_capacity %}
+    {% if timeslot.has_capacity and not timeslot_has_passed %}
       <div class="card bg-light mb-4">
         <div class="card-header">Timeslot</div>
         <div class="card-body">

--- a/timeslots/views.py
+++ b/timeslots/views.py
@@ -76,14 +76,11 @@ def timeslot_detail(request, area_id, slug):
     area = Area.objects.get(pk=area_id)
     timeslot = get_or_create_timeslot(slug)
 
-    if (request.user == area.area_manager.id):
-        if request.method == POST:
-            pass
-
     return render(request, 'timeslots/timeslot_detail.html', {
         'area': area,
         'timeslot': get_or_create_timeslot(slug),
-        'show_manager_options': request.user.id == area.area_manager.id
+        'show_manager_options': request.user.id == area.area_manager.id,
+        'timeslot_has_passed': timeslot.start_time < tz_now()
     })
 
 @login_required
@@ -91,6 +88,11 @@ def timeslot_detail(request, area_id, slug):
 def reservation_form(request, area_id, slug):
     area = Area.objects.get(pk=area_id)
     timeslot = get_or_create_timeslot(slug)
+
+    if timeslot.end_time < tz_now():
+        messages.error(request, 'You cannot reserve a timeslot in the past.')
+        return HttpResponseRedirect('/timeslots/')
+
     if request.method == 'POST':
         form = ReservationForm(request.POST)
         if form.is_valid():


### PR DESCRIPTION
This has proven to be a source of confusion a couple of times in the past, and it's easy enough to close this hole.

Note that we're only preventing this in the member-facing user interface. People with the appropriate access can retroactively create reservations in the admin panel.