### PR TITLE
Create sso account by default when importing accounts from Civicrm

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -48,7 +48,7 @@ class PasswordChangeForm(forms.Form):
 class CiviCRMContactImportForm(forms.Form):
     contact_id = forms.IntegerField(help_text='CiviCRM Contact ID', required=True)
     create_sso_account_and_invite = forms.BooleanField(
-        help_text='Create SSO account and invite to dashboard', required=False
+        help_text='Create SSO account and invite to dashboard', default=True, required=False
     )
 
 class CognitoAdminForm(forms.Form):


### PR DESCRIPTION
Change targeted to prevent import errors where membership coordinators forget to check a box to create a SSO account for returning members.